### PR TITLE
Use hasOwnProperty instead of in

### DIFF
--- a/lib/ParserStream.js
+++ b/lib/ParserStream.js
@@ -55,7 +55,7 @@ class ParserStream extends Readable {
   parse (data) {
     return ParserStream.toJson(data).then((json) => {
       // forward context as prefixes if available
-      if ('@context' in json) {
+      if (json.hasOwnProperty('@context')) {
         Object.keys(json['@context']).forEach((prefix) => {
           this.emit('prefix', prefix, this.factory.namedNode(json['@context'][prefix]))
         })


### PR DESCRIPTION
Tiny change here to avoid looking up the prototype chain if the object doesn't have `@context` as own property.